### PR TITLE
highlights: add sail syntax

### DIFF
--- a/languages/hoon/highlights.scm
+++ b/languages/hoon/highlights.scm
@@ -1,4 +1,36 @@
+(rune) @operator
+
+;; Basic elements
+(lineComment) @comment
+(name) @label
+(term) @constant
 (number) @number
+(string) @string
+(boolean) @boolean
+
+;; Special constructs
+(cell) @punctuation.bracket
+(gateCall) @function.call
+(mold) @type
+
+;; Aura and special types
+(aura) @type.builtin
+(fullContext) @constant.builtin
+(stripFace) @constant.builtin
+
+;; Terminators
+(seriesTerminator) @punctuation.delimiter
+(coreTerminator) @punctuation.delimiter
+
+;; Highlighting for special characters
+["(" ")" "[" "]" "{" "}" "," "."] @punctuation.delimiter
+
+(sailTagTall (name) @tag)
+(sailTagWide (name) @tag)
+(sailId) @property
+(sailClass) @attribute
+(sailAttributeTall) @attribute(number) @number
+(sailAttributeWide) @attribute(number) @number
 
 (string) @string
 
@@ -7,26 +39,42 @@
   ")"
   "["
   "]"
-]  @punctuation.bracket
+] @punctuation.bracket
 
 [
   (coreTerminator)
   (seriesTerminator)
 ] @punctuation.delimiter
 
-
-(rune) @keyword
-
 (term) @constant
 
 (aura) @constant.builtin
 
-(Gap) @comment
+(lineComment) @comment
 
 (boolean) @constant.builtin
 
-(date) @constant.builtin
-(mold) @constant.builtin
-(specialIndex) @constant.builtin
+(date) @string.special
+
+(mold) @string.special.symbol
+
+(specialIndex) @number
+
 (lark) @operator
-(fullContext) @constant.builtin
+
+(fullContext) @string.special.symbol
+;; Core runes
+(luslusTall (rune) @module)  ;; ++
+(lusbucTall (rune) @type.definition)     ;; +$
+(bartisTall (rune) @function) ;; |=
+
+;; Other common runes
+(colhepTall (_) @constructor) ;; :-
+(collusTall (rune) @constructor) ;; :+
+(bardotTall (rune) @keyword.builtin)  ;; |.
+(barhepTall (rune) @function.repeat)  ;; |-
+(tisgarTall (rune) @keyword.modifier) ;; =>
+(centisWide (rune) @keyword.modifier) ;; %=
+(wutcolTall (rune) @keyword.conditional) ;; ?:
+(wutdotTall (rune) @keyword.conditional) ;; ?.
+(tisfasTall (rune) @variable.builtin) ;; =/


### PR DESCRIPTION
This extends the highlighting syntax to support sail templates by merging in the changes from the illustrious ~littel-wolfur here:

https://github.com/ryjm/tree-sitter-hoon-1/blob/remove-gap/queries/highlights.scm